### PR TITLE
Correct CO2 reference data

### DIFF
--- a/docs/Grove-CO2_Sensor.md
+++ b/docs/Grove-CO2_Sensor.md
@@ -141,8 +141,7 @@ Reference
 -   350~450ppm: General outdoor environment
 -   350~1000ppm：The air is fresh and breathing smooth
 -   1000~2000ppm：The air was stagnant and feel asleep
--   2000~5000ppm：headache, asleep, dull, unable To Focus, heart beat rock and even mild nausea
--   &gt;5000ppm：severe depletion of oxygen, permanent brain damage and even death
+-   5000ppm：Permissible exposure limit for an 8h work day
 
 Resources
 ---------


### PR DESCRIPTION
5000ppm of CO2 is not deadly, you're thinking of >5%, which would be 50 000ppm. 
5000ppm is actually the permissible exposure limit set by the US Occupational Safety and Health Administration (OSHA) for an eight hour work day. 30 000ppm is defined as a ceiling exposure limit for 10 minutes. 4% can lead to intoxication, ~7% to unconsciousness, ~9% over 5 minutes may lead to death.  Source: http://www.blm.gov/style/medialib/blm/wy/information/NEPA/cfodocs/howell.Par.2800.File.dat/25apxC.pdf (which has some extra data and references)