### PR TITLE
Link FogLight Grove Java Libraries

### DIFF
--- a/docs/Grove-3-Axis_Digital_Accelerometer-1.5g.md
+++ b/docs/Grove-3-Axis_Digital_Accelerometer-1.5g.md
@@ -148,6 +148,12 @@ The second figure gives some examples:
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-3-Axis_Digital_Accelerometer-1.5g/master/img/Sensing_Direction_1.jpg)
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove 3 Axis Accelerometer - 1.5g](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/ThreeAxisAccelerometer/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 Resources
 ---------
 

--- a/docs/Grove-4-Digit_Display.md
+++ b/docs/Grove-4-Digit_Display.md
@@ -358,6 +358,13 @@ sudo python grove_4_digit_display.py
 cd yourpath/GrovePi/Firmware
 sudo ./firmware_update.sh
 ```
+
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove 4 Digit Display](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/FourDigitDisplay/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ##Project
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Seeeduino_Lotus/master/img/gun.jpg)

--- a/docs/Grove-6-Axis_AccelerometerAndCompass_V2.0.md
+++ b/docs/Grove-6-Axis_AccelerometerAndCompass_V2.0.md
@@ -85,6 +85,12 @@ Please refer [here](https://raw.githubusercontent.com/SeeedDocument/Grove-6-Axis
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-6-Axis_AccelerometerAndCompass_V2.0/master/img/Testing.jpg)
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove 6 Axis Accelerometer and Compass v2.0](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/SixAxisAccelerometer/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 Resources
 ---------
 

--- a/docs/Grove-Button.md
+++ b/docs/Grove-Button.md
@@ -134,6 +134,7 @@ cd GrovePi/Software/Python/
 sudo python grove_button.py
 ```
 
+
 **Related Grove Packer**
 
 The standard Grove - Button module is available as part of the following Grove Kit Series:
@@ -143,6 +144,12 @@ The standard Grove - Button module is available as part of the following Grove K
 |![](https://github.com/SeeedDocument/Grove_Button/raw/master/image/mixer%20pack%20v2.jpg)|![](https://github.com/SeeedDocument/Grove_Button/raw/master/image/mixer%20pack.jpg)|![](https://github.com/SeeedDocument/Grove_Button/raw/master/image/Newbundle1.jpg)|
 |<a href="https://www.seeedstudio.com/Mixer-Pack-V2(Electronic-blocks%2Cwithout-Arduino%2Cplug-and-play-system)-p-1867.html">Get One Now</a>|[Get One Now](https://www.seeedstudio.com/Grove-Mixer-Pack-p-1590.html)|[Get One Now](https://www.seeedstudio.com/Grove-Starter-Kit-for-Arduino-p-1855.html)|
 Alternatively, it can be bought stand-alone [here](https://www.seeedstudio.com/Grove-Button-p-766.html)at the Seeed Studio [Bazaar](https://www.seeedstudio.com/). To buy the Panel Mount version of the module, go to [here](http://www.seeedstudio.com/depot/Grove-ButtonP-p-1243.html)
+
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Button](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/Button/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
 
 
 ##Project

--- a/docs/Grove-Buzzer.md
+++ b/docs/Grove-Buzzer.md
@@ -189,6 +189,12 @@ Run Program
 ```sudo python grove_buzzer.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Buzzer](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/Buzzer/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ##Project
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Seeeduino_Lotus/master/img/gun.jpg)

--- a/docs/Grove-I2C_ADC.md
+++ b/docs/Grove-I2C_ADC.md
@@ -377,6 +377,14 @@ In order to find out which result is more close to the actual condition, here we
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Grove-I2C_ADC/master/img/Measure_the_real_sensor_value_using_DMM.JPG)
 
+
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove I2C ADC](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/AnalogToIIC/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
+
 Resources
 --------
 

--- a/docs/Grove-I2C_Motor_Driver_V1.3.md
+++ b/docs/Grove-I2C_Motor_Driver_V1.3.md
@@ -247,6 +247,14 @@ void StepperRun(int _step);
 
 **_step** represents the steps you set to the stepper motor to run. You can fill -1024~1024. When _step>0, stepper motor runs clockwise, while _step<0, stepper motor runs anticlockwise. When _step is 512/-512, the stepper motor will run a complete turn and if _step is 1024/-1024, the stepper motor will run 2 turns. The stepper motor will stop automatically after it finishes its steps.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove I2C Motor Driver v1.3](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/IICMotorDriver/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
+
+
 Resources
 ---------
 

--- a/docs/Grove-LCD_RGB_Backlight.md
+++ b/docs/Grove-LCD_RGB_Backlight.md
@@ -111,6 +111,12 @@ Modify the code about color into:
 
 Upload the code again, woo, see the backlight turn to Red? Then why not try another color? Whatever you like.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove LCD RGB Backlight](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/LCDRGB/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 
 ## Resources
 

--- a/docs/Grove-LED_Socket_Kit.md
+++ b/docs/Grove-LED_Socket_Kit.md
@@ -123,6 +123,12 @@ cd GrovePi/Software/Python/
 sudo python grove_led_blink.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove LED Socket Kit](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/LED/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ##  Resources
 ---
 *   [Grove - LED V1.3 Source files (Eagle and pdf)](https://github.com/SeeedDocument/Grove-LED_Socket_Kit/raw/master/res/Grove-LED_v1.3_Schematics.zip)

--- a/docs/Grove-Light_Sensor.md
+++ b/docs/Grove-Light_Sensor.md
@@ -129,6 +129,12 @@ Have fun.
 
 ![enter image description here](https://raw.githubusercontent.com/SeeedDocument/Grove_Light_Sensor/master/images/secret_box.png)
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Light Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/LightSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ##Project
 
 ![](https://raw.githubusercontent.com/SeeedDocument/Seeeduino_Lotus/master/img/gun.jpg)

--- a/docs/Grove-Line_Finder.md
+++ b/docs/Grove-Line_Finder.md
@@ -112,6 +112,12 @@ while True:
    sudo python grove_line_finder.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Line Finder](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/LineFinder/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ## Resources
 ---
 - [Eagle files](https://github.com/SeeedDocument/Grove_Line_Finder/raw/master/res/202000970_Grove%20-%20Line%20Finder%20v1.0_eagle%20files.zip)

--- a/docs/Grove-Mini_I2C_Motor_Driver_v1.0.md
+++ b/docs/Grove-Mini_I2C_Motor_Driver_v1.0.md
@@ -417,6 +417,13 @@ Now click Upload(CTRL+U) to burn testing code. Please refer to [here](/Arduino_C
 
 After upload is complete, the motors will rotate in the positive or opposite direction in cycle.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Mini I2C Motor Driver v1.0](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/IICMiniMotorDriver/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
+
 Resources
 ---------
 

--- a/docs/Grove-Moisture_Sensor.md
+++ b/docs/Grove-Moisture_Sensor.md
@@ -185,6 +185,12 @@ print "Error
 ```
 sudo python grove_moisture_sensor.py
 ```
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Moisture Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/MoistureSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 
 ## Resources
 ---

--- a/docs/Grove-OLED_Display_0.96inch.md
+++ b/docs/Grove-OLED_Display_0.96inch.md
@@ -353,6 +353,13 @@ if __name__=="__main__":
 
 **Step5**: Run the code. We'll find that the Grove - OLED outputs "Hello World".
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove OLED Display 0.96inch](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/OLED128x64/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
+
 ## Resources
 -----------
 - **[Eagle]** [Grove-OLED128x64](https://github.com/SeeedDocument/Grove_OLED_Display_0.96/raw/master/resource/OLED%20128x64.zip)

--- a/docs/Grove-OLED_Display_1.12inch.md
+++ b/docs/Grove-OLED_Display_1.12inch.md
@@ -237,6 +237,12 @@ Example:
 
     SeeedGrayOled.activateScroll();   //Disable scrolling.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove OLED Display 1.12inch](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/OLED96x96/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ## Resources
 ---------
 * **[Eagle]** [Grove-OLED Display 1.12inch in Eagle](https://github.com/SeeedDocument/Grove_OLED_1.12/raw/master/resources/OLED%20Display.zip)

--- a/docs/Grove-Piezo_Vibration_Sensor.md
+++ b/docs/Grove-Piezo_Vibration_Sensor.md
@@ -171,6 +171,12 @@ First of all, we need to prepare the below stuffs:
     sudo python grove_piezo_vibration_sensor.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Piezo Vibration Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/VibrationSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ## Resources
 ---------
 

--- a/docs/Grove-RTC.md
+++ b/docs/Grove-RTC.md
@@ -379,6 +379,12 @@ Without Grove Shield,you can connect to Arduino by increasing an Pinout to a gro
 | SDA   | SDA     |
 | SCL   | SCL     |
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove RTC](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/RealTimeClock/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ## Resources
 ---------
 

--- a/docs/Grove-Relay.md
+++ b/docs/Grove-Relay.md
@@ -194,6 +194,11 @@ cd GrovePi/Software/Python/
 ```
 sudo python grove_switch_relay.py
 ```
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Relay](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/Relay/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
 
 ## Resources
 ----

--- a/docs/Grove-Rotary_Angle_Sensor.md
+++ b/docs/Grove-Rotary_Angle_Sensor.md
@@ -318,6 +318,13 @@ This example uses ADC channel 0 to get the value of the rotary angle.Then gives 
     sudo python grove_rotary_angle_sensor.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Rotary Angle Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/AngleSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
+
 Resources
 ---------
 

--- a/docs/Grove-Temperature_Sensor.md
+++ b/docs/Grove-Temperature_Sensor.md
@@ -242,6 +242,12 @@ print "Error"
 **Step6:** Run the code.
 You'll find that the terminal outputs Temperature value every 2 seconds.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Temperature Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/Temprature/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ##  Resource
 ---
 *   [Grove - Temperature Sensor v1.0 Eagle File](https://github.com/SeeedDocument/Grove-Temperature_Sensor/raw/master/res/Grove-Temperature_Sensor-Analog-v1.0_Source_File.zip)

--- a/docs/Grove-Thumb_Joystick.md
+++ b/docs/Grove-Thumb_Joystick.md
@@ -179,6 +179,11 @@ The output value from the analog port of Arduino can be converted to the corresp
 ```
     sudo python grove_thumb_joystick.py
 ```
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Thumb Joystick](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/ThumbJoystick/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
 
 Resources
 ---------

--- a/docs/Grove-Touch_Sensor.md
+++ b/docs/Grove-Touch_Sensor.md
@@ -115,6 +115,11 @@ void loop() {
 
         sudo python grove_touch_sensor.py
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Touch Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/TouchSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
 
 Resources
 ---------

--- a/docs/Grove-UV_Sensor.md
+++ b/docs/Grove-UV_Sensor.md
@@ -122,6 +122,12 @@ void loop()
 }
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove UV Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/UVSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 Resources
 ---------
 

--- a/docs/Grove-Ultrasonic_Ranger.md
+++ b/docs/Grove-Ultrasonic_Ranger.md
@@ -202,6 +202,12 @@ pi@raspberrypi:~/GrovePi/Software/Python $ python grove_ultrasonic.py
 ## FAQs
 Please click [here](http://support.seeedstudio.com/knowledgebase/articles/1822222-grove-ultrasonic-ranger-sku-101020010) to see all Grove-Ultrasonic Ranger FAQs.
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Ultrasonic Ranger](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/UltrasonicRangefinder/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 ## Resources
 ---
 - **[PDF]** [Grove_Ultrasonic Ranger Schematic](https://github.com/SeeedDocument/Grove_Ultrasonic_Ranger/raw/master/res/Grove_Ultrasonic%20Ranger%20Schematic.pdf)

--- a/docs/Grove-Variable_Color_LED.md
+++ b/docs/Grove-Variable_Color_LED.md
@@ -90,6 +90,11 @@ void loop()  {
 ```
 -   Upload the code.Adjust the three adjustable resistances, I am sure you will like it. Have a try!
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Variable Color LED](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/VariableColorLED/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
 
 Resources
 ---------

--- a/docs/Grove-Water_Sensor.md
+++ b/docs/Grove-Water_Sensor.md
@@ -238,6 +238,12 @@ while True:
 sudo python grove_water_sensor.py
 ```
 
+## Try it in JAVA!
+
+Check out this tutorial for the [Grove Water Sensor](https://github.com/oci-pronghorn/FogLight-Grove/blob/master/WaterSensor/README.md).   
+Its part of the open source framework FogLight where  many of the [Grove Devices](https://github.com/oci-pronghorn/FogLight-Grove) are supported. 
+It was designed for IoT applications and provides an integrated web server.   
+
 Resources
 ---------
 


### PR DESCRIPTION
Add a link to the FogLight Grove Java Libraries.  There is a  very descriptive tutorial on how to set up, build and run the examples using Java and the FogLight opensource IoT framework.   